### PR TITLE
Add native window support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,10 +1,30 @@
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.13)
 set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 
 project(hello)
 set(CMAKE_CXX_STANDARD 17)
 
 if(NOT EMSCRIPTEN)
+    # Turning off OpenGL for Dawn
+    set(DAWN_ENABLE_PIC        ON CACHE BOOL "Position-Independent-Code")
+    set(DAWN_ENABLE_DESKTOP_GL OFF CACHE BOOL "OpenGL backend")
+    set(DAWN_ENABLE_OPENGLES   OFF CACHE BOOL "OpenGL ES backend")
+    set(DAWN_BUILD_EXAMPLES    OFF CACHE BOOL "Dawn examples")
+    set(TINT_BUILD_SAMPLES     OFF CACHE BOOL "Tint examples")
+    set(TINT_BUILD_GLSL_WRITER OFF CACHE BOOL "OpenGL SL writer")
+
+    # Use GLFW for native window support (on Linux)
+    if (NOT DEFINED DEMO_USE_GLFW)
+        option(DEMO_USE_GLFW "Demo use glfw for native window platform" ON)
+    endif()
+
+    if (DEMO_USE_GLFW)
+        message("Demo use glfw for native window platform is turned on. If glfw is not found try `apt-get install libglfw3-dev`")
+        find_package(glfw3 REQUIRED)
+        set(DAWN_USE_X11 ON CACHE BOOL "Dawn use X11")
+        set(DAWN_GLFW_DIR "third_party/glfw3" CACHE BOOL "Dawn use GLFW")
+    endif()
+
     add_subdirectory("third_party/dawn" EXCLUDE_FROM_ALL)
 endif()
 
@@ -12,11 +32,10 @@ if(EMSCRIPTEN)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g")
 endif()
 
-add_executable(hello
-    "main.cpp"
-    )
-
 if(EMSCRIPTEN)
+    add_executable(hello
+        "main.cpp"
+    )
     set_target_properties(hello PROPERTIES
         SUFFIX ".html")
     target_link_options(hello
@@ -29,10 +48,31 @@ if(EMSCRIPTEN)
         #PRIVATE "SHELL:-s VERBOSE=1"
         )
 else()
-    target_link_libraries(hello
-        dawn_headers
-        dawncpp
-        dawn_native
-        dawn_proc
+    if (DEMO_USE_GLFW)
+        add_executable(hello
+            "window.h"
+            "main.cpp"
         )
+        target_compile_definitions(hello PRIVATE DEMO_USE_GLFW)
+        target_link_libraries(hello
+            dawn_headers
+            dawncpp_headers
+            dawncpp
+            dawn_native
+            dawn_proc
+            webgpu_glfw
+            glfw
+        )
+    else()
+        add_executable(hello
+            "main.cpp"
+        )
+        target_link_libraries(hello
+            dawn_headers
+            dawncpp_headers
+            dawncpp
+            dawn_native
+            dawn_proc
+        )
+    endif()
 endif()

--- a/README.md
+++ b/README.md
@@ -21,9 +21,6 @@ Instructions are for Linux/Mac; they will need to be adapted to work on Windows.
 
 Build has only been tested on Linux/Mac.
 
-If you run into issues building the OpenGL or OpenGL ES backend, add these options to your `cmake`
-invocation: `-DDAWN_ENABLE_DESKTOP_GL=OFF -DDAWN_ENABLE_OPENGLES=OFF`
-
 ```sh
 ./setup_native_build.sh
 mkdir -p out/native
@@ -36,6 +33,20 @@ Then:
 cmake ../..
 make -j4 clean all
 ```
+
+Note: If you want to have window displayed, make sure to have glfw available.
+e.g. to install on Linux/Ubuntu:
+
+```sh
+apt-get install libglfw3-dev
+```
+
+Alternatively, you can disable using glfw and window display by
+
+```sh
+cmake ../.. -DDEMO_USE_GLFW=OFF
+```
+
 
 Or, to use Ninja instead of Make:
 

--- a/window.h
+++ b/window.h
@@ -1,0 +1,31 @@
+#ifndef WINDOW_H
+#define WINDOW_H
+
+#include <stdint.h>
+
+typedef struct window_config_t {
+  const char* title;
+  uint32_t width;
+  uint32_t height;
+  int resizable;
+} window_config_t;
+
+typedef struct window window_t;
+typedef struct {
+  void (*scroll_callback)(window_t* window, int ctrl_key, int shift_key,
+                          float mouse_x, float mouse_y, float wheel_delta_y);
+  void (*resize_callback)(window_t* window, int width, int height);
+} callbacks_t;
+
+/* window related functions */
+window_t* window_create(window_config_t* config);
+void window_destroy(window_t* window);
+int window_should_close(window_t* window);
+void window_set_title(window_t* window, const char* title);
+void window_set_userdata(window_t* window, void* userdata);
+void* window_get_userdata(window_t* window);
+void* window_get_surface(window_t* window);
+void window_get_size(window_t* window, uint32_t* width, uint32_t* height);
+void window_get_aspect_ratio(window_t* window, float* aspect_ratio);
+
+#endif


### PR DESCRIPTION
Add native window support via glfw.

It's now on by default. It can be turned off by appending `-DDEMO_USE_GLFW=OFF` to `cmake`