### PR TITLE
Add Gitpod Configuration

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,8 +1,12 @@
 image: emscripten/emsdk
 
 tasks:
-  - name: Emscripten
+  - name: Emscripten Build
     command: |
       cd out/web
       emcmake cmake ../..
       make -j4 clean all
+  - name: Dev-Server
+    command: |
+      cd out/web
+      python3 -m http.server 8080

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,8 @@
+image: emscripten/emsdk
+
+tasks:
+  - name: Emscripten
+    command: |
+      cd out/web
+      emcmake cmake ../..
+      make -j4 clean all

--- a/README.md
+++ b/README.md
@@ -13,6 +13,9 @@ but that is a goal.
 
 **Check the [issues](https://github.com/kainino0x/webgpu-cross-platform-demo/issues) tab for known issues.**
 
+## Open pre-installed VSCode in Browser
+[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/kainino0x/webgpu-cross-platform-demo)
+
 ## Building
 
 Instructions are for Linux/Mac; they will need to be adapted to work on Windows.


### PR DESCRIPTION
I thought it might be convenient for users to explore a pre-configured emscription build environment with a single click.

Until this PR get's merged, the .gitpod.yml config can be tested via https://gitpod.io#https://github.com/haraldreingruber/webgpu-cross-platform-demo

Please let me know what you think?